### PR TITLE
error in page : cannot read property getcontext of undefined at htmld…

### DIFF
--- a/src/assets/dist/js/pages/dashboard2.js
+++ b/src/assets/dist/js/pages/dashboard2.js
@@ -1,5 +1,6 @@
 $(function () {
 
+  var Grid = function(width, height) {
   'use strict';
 
   /* ChartJS
@@ -271,4 +272,5 @@ $(function () {
       spotColor: $this.data('spotcolor')
     });
   });
+  }
 });


### PR DESCRIPTION
…ocument anonymous dashboard2 js 15

I guess the problem is your js runs before the html is loaded.
If you are using jquery, you can use the document ready function to wrap your code:
reffer: https://stackoverflow.com/questions/10291693/cannot-read-property-getcontext-of-null-using-canvas/40619137

goto->src->assets->dist->js->dashboard2.js and change
$(function() {
    var Grid = function(width, height) {
        // codes...
    }
});